### PR TITLE
Allow parsing without inlining.

### DIFF
--- a/Data/Config/Internal/Typed.hs
+++ b/Data/Config/Internal/Typed.hs
@@ -36,14 +36,14 @@ data Type
 data TypeLit
     = StringLit
     | ObjectLit
-    deriving Eq
+    deriving (Eq, Show)
 
 --------------------------------------------------------------------------------
 data Typed
     = Typed
     { typedType  :: Type
     , typedScope :: Scoped
-    }
+    } deriving Show
 
 --------------------------------------------------------------------------------
 instance Show Type where


### PR DESCRIPTION
Following up #10 .

Giving this configuration:
```
foo {
    port: 1234
    addr: localhost

    baz {
        test = "hello"
    }
}
```

produces this AST:

```
fromList [("foo",AST {astExpr = OBJECT [Prop {propName = "port", propAST = AST {astExpr = STRING "1234", astTag = Typed {typedType = String, typedScope = Scoped {scopeProp = "foo", scopeName = "foo.port", scopePos = 2:11-15:}}}},Prop {propName = "addr", propAST = AST {astExpr = STRING "localhost", astTag = Typed {typedType = String, typedScope = Scoped {scopeProp = "foo", scopeName = "foo.addr", scopePos = 3:11-20:}}}},Prop {propName = "baz", propAST = AST {astExpr = OBJECT [Prop {propName = "test", propAST = AST {astExpr = STRING "hello", astTag = Typed {typedType = String, typedScope = Scoped {scopeProp = "foo", scopeName = "foo.baz.test", scopePos = 6:16-23:}}}}], astTag = Typed {typedType = Object, typedScope = Scoped {scopeProp = "foo", scopeName = "foo.baz", scopePos = 5-7:9-6:}}}}], astTag = Typed {typedType = Object, typedScope = Scoped {scopeProp = "foo", scopeName = "foo", scopePos = 1-8:5-2:}}})]
```
This patch should do what you need @dwijnand